### PR TITLE
Feature: add rename function

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,1 @@
-dev
-nohup.out
-.travis.yml
-appveyor.yml
-travis*
-ci
+.vscode

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const replace = require('gulp-replace')
+const gulpReplace = require('gulp-replace')
 
 // defaults
 const defaultPrefix = 'package'
@@ -158,7 +158,7 @@ function mergeReplacements (replacements) {
  * @param {GulpReplaceTmplOptions} options configure replacement
  * @return {NodeJS.ReadWriteStream} transformation function
  */
-function GulpReplaceTmpl (replacements, options) {
+function replace (replacements, options) {
   const _options = options || {}
   // required option missing
   if (!replacements) {
@@ -193,7 +193,22 @@ function GulpReplaceTmpl (replacements, options) {
     console.log('Replacements:', mergedReplacements)
   }
 
-  return replace(pattern, handler)
+  return gulpReplace(pattern, handler)
 }
 
-module.exports = GulpReplaceTmpl
+/**
+ * Rename function for use with gulp-rename
+ * Removes the extension off of a file's name
+ * Example: a.txt.tmpl will be renamed to a.txt
+ *
+ * @param {{dirname: string, basename: string, extname: string}} path
+ */
+function removeFileExtension (path) {
+  path.extname = ""
+}
+
+module.exports = {
+  replace,
+  removeFileExtension,
+  default: replace
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@existdb/gulp-replace-tmpl",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@existdb/gulp-replace-tmpl",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@existdb/gulp-replace-tmpl",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Replace placeholders in files",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@existdb/gulp-replace-tmpl",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Replace placeholders in files",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Because this changes the export of the package, this is a breaking change.
I would therefore like to hear if it is worth it.

It allows for the following

```js
// breaking change
const {replace, removeExtension} = require('@existdb/gulp-replace-tmpl')
// was before
// const replace = require('@existdb/gulp-replace-tmpl')

const rename = require('gulp-rename')
const replacements = {"a": "b"}

function templates () {
  return src(tmplFiles)
    .pipe(replace(replacements))

    // allows for
    .pipe(rename(removeExtension))
    // instead of 
    // .pipe(rename(path => { path.extname = "" }))

    .pipe(dest('build'))
}
exports = {templates}
```